### PR TITLE
Rename dump methods to dumpState (again)

### DIFF
--- a/libs/gui/tests/BufferQueue_test.cpp
+++ b/libs/gui/tests/BufferQueue_test.cpp
@@ -904,7 +904,7 @@ TEST_F(BufferQueueTest, TestDiscardFreeBuffers) {
 
     // Check no free buffers in dump
     String8 dumpString;
-    mConsumer->dump(dumpString, nullptr);
+    mConsumer->dumpState(dumpString, nullptr);
 
     // Parse the dump to ensure that all buffer slots that are FREE also
     // have a null GraphicBuffer


### PR DESCRIPTION
This fixes:
ERROR: no member named 'dump' in 'android::IGraphicBufferConsumer'

 * While compiling for the emulator only

From:
https://github.com/CyanogenMod/android_frameworks_native/commit/1ae08f89f7fa1737cd1291842b76fa98e550f60d

Originated:
https://android.googlesource.com/platform/frameworks/native/+/5fa1223322175356e6ac943cb06d8b1e1cfc39d9

Change-Id: I7f66286b54f9d3a2b02f82cbc0518cd306df8aea